### PR TITLE
Update GitHub token reference in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,5 +27,5 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.MY_GITHUB_TOKEN }}
           publish_dir: ./build


### PR DESCRIPTION
Update the GitHub token reference in the workflow file.

* Rename the secret reference from `GITHUB_TOKEN` to `MY_GITHUB_TOKEN` in the `Deploy to GitHub Pages` job in `.github/workflows/deploy.yml`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/istc-cnr/experiment_danger_rating/pull/3?shareId=3585bf84-3b21-40d9-913c-13ff16a526af).