### PR TITLE
Add build script to package.json and set MONGODB_URI in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Set MONGODB_URI environment variable
+        run: echo "MONGODB_URI=${{ secrets.MONGODB_URI }}" >> $GITHUB_ENV
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node server.js",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "build": "node src/server.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Add a build script to the `package.json` file and set the `MONGODB_URI` environment variable in the GitHub Actions workflow.

* **package.json**
  - Add a `build` script to the `scripts` section with the command `node src/server.js`.
  - Ensure the `predeploy` script references `npm run build`.

* **.github/workflows/deploy.yml**
  - Add a step to set the `MONGODB_URI` environment variable from GitHub secrets.

